### PR TITLE
BLD: Explicitly set pandas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 env:
   global:
       - REPO_DIR=statsmodels
-      - BUILD_COMMIT=v0.9.0
+      - BUILD_COMMIT=master
       - PLAT=x86_64
       - UNICODE_WIDTH=32
       - NP_BUILD_DEP="numpy==1.11.0"
       - NP_TEST_DEP="numpy==1.11.0"
       - SP_BUILD_DEP="scipy==0.18.0"
       - SP_TEST_DEP="scipy==0.18.0"
+      - PANDAS_DEP="pandas==0.20.3"
       - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
       - MANYLINUX_URL=https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com
       # Following generated with
@@ -67,14 +68,7 @@ matrix:
         - NP_TEST_DEP=numpy==1.14.5
         - SP_BUILD_DEP=scipy==1.1.0
         - SP_TEST_DEP=scipy==1.1.0
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.7
-        - PLAT=i686
-        - NP_BUILD_DEP=numpy==1.14.5
-        - NP_TEST_DEP=numpy==1.14.5
-        - SP_BUILD_DEP=scipy==1.1.0
-        - SP_TEST_DEP=scipy==1.1.0
+        - PANDAS_DEP=pandas
     - os: osx
       language: generic
       env: MB_PYTHON_VERSION=2.7
@@ -98,6 +92,7 @@ matrix:
         - NP_TEST_DEP=numpy==1.14.5
         - SP_BUILD_DEP=scipy==1.1.0
         - SP_TEST_DEP=scipy==1.1.0
+        - PANDAS_DEP=pandas
 
 before_install:
     - if [ "$TRAVIS_BRANCH" == "master" ]; then
@@ -108,7 +103,7 @@ before_install:
           UPLOAD_ARGS="--no-update-index";
       fi
     - BUILD_DEPENDS="$NP_BUILD_DEP $SP_BUILD_DEP Cython"
-    - TEST_DEPENDS="$NP_TEST_DEP $SP_TEST_DEP pandas nose pytest pytest-xdist"
+    - TEST_DEPENDS="$NP_TEST_DEP $SP_TEST_DEP $PANDAS_DEP nose pytest pytest-xdist"
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh
     - before_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   global:
       - REPO_DIR=statsmodels
-      - BUILD_COMMIT=797c613
+      - BUILD_COMMIT=master
       - PLAT=x86_64
       - UNICODE_WIDTH=32
       - NP_BUILD_DEP="numpy==1.11.0"
@@ -111,10 +111,6 @@ before_install:
 
 install:
     # Maybe get and clean and patch source
-    - cd statsmodels
-    - git remote add pq https://github.com/thequackdaddy/statsmodels
-    - git fetch --all
-    - cd ..
     - clean_code $REPO_DIR $BUILD_COMMIT
     - build_wheel $REPO_DIR $PLAT
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   global:
       - REPO_DIR=statsmodels
-      - BUILD_COMMIT=master
+      - BUILD_COMMIT=v0.10.0rc2
       - PLAT=x86_64
       - UNICODE_WIDTH=32
       - NP_BUILD_DEP="numpy==1.11.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ before_install:
           UPLOAD_ARGS="--no-update-index";
       fi
     - BUILD_DEPENDS="$NP_BUILD_DEP $SP_BUILD_DEP Cython"
-    - TEST_DEPENDS="$NP_TEST_DEP $SP_TEST_DEP $PANDAS_DEP nose pytest pytest-xdist pytest-randomly"
+    - TEST_DEPENDS="$NP_TEST_DEP $SP_TEST_DEP $PANDAS_DEP nose pytest pytest-xdist"
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh
     - before_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
       - secure: "J6Qw/teEz1ZotJIFI113Zn9oXJRmDgRR9Ue3ZsHjhDVV6EEHS2UwXDrqX/2NQyGax3CONiGgDkZ6TThz+yv4vdUY/8/lC6IC1kXTGIs5UjgQ1BTCQG7tKOK/ce3EEPqTcgAd1PnwyLpab5dLWIcyLJkCnWQHDNU0HiuBjp3w+2c="
       # Commit when running from master branch
       - DAILY_COMMIT=master
+      - PYTHONHASHSEED=0
 
 language: python
 # Default Python version is usually 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ before_install:
           UPLOAD_ARGS="--no-update-index";
       fi
     - BUILD_DEPENDS="$NP_BUILD_DEP $SP_BUILD_DEP Cython"
-    - TEST_DEPENDS="$NP_TEST_DEP $SP_TEST_DEP $PANDAS_DEP nose pytest pytest-xdist"
+    - TEST_DEPENDS="$NP_TEST_DEP $SP_TEST_DEP $PANDAS_DEP nose pytest pytest-xdist pytest-randomly"
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh
     - before_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   global:
       - REPO_DIR=statsmodels
-      - BUILD_COMMIT=master
+      - BUILD_COMMIT=797c613
       - PLAT=x86_64
       - UNICODE_WIDTH=32
       - NP_BUILD_DEP="numpy==1.11.0"
@@ -104,13 +104,17 @@ before_install:
           UPLOAD_ARGS="--no-update-index";
       fi
     - BUILD_DEPENDS="$NP_BUILD_DEP $SP_BUILD_DEP Cython"
-    - TEST_DEPENDS="$NP_TEST_DEP $SP_TEST_DEP $PANDAS_DEP nose pytest pytest-xdist"
+    - TEST_DEPENDS="$NP_TEST_DEP $SP_TEST_DEP $PANDAS_DEP nose pytest pytest-xdist pytest-randomly"
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh
     - before_install
 
 install:
     # Maybe get and clean and patch source
+    - cd statsmodels
+    - git remote add pq https://github.com/thequackdaddy/statsmodels
+    - git fetch --all
+    - cd ..
     - clean_code $REPO_DIR $BUILD_COMMIT
     - build_wheel $REPO_DIR $PLAT
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -79,7 +79,7 @@ build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
   # Install the test dependencies
-  - pip install %NP_TEST_DEP% %SP_TEST_DEP% patsy %PANDAS_DEP% nose pytest pytest-xdist
+  - pip install %NP_TEST_DEP% %SP_TEST_DEP% patsy %PANDAS_DEP% nose pytest pytest-xdist pytest-randomly
   - pip install --pre --no-index --find-links .\%REPO_DIR%\dist %PKG_NAME%
   # Change into an innocuous directory and find tests from installation
   - mkdir for_testing

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,7 +80,7 @@ build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
   # Install the test dependencies
-  - pip install %NP_TEST_DEP% %SP_TEST_DEP% patsy %PANDAS_DEP% nose pytest pytest-xdist pytest-randomly
+  - pip install %NP_TEST_DEP% %SP_TEST_DEP% patsy %PANDAS_DEP% nose pytest pytest-xdist
   - pip install --pre --no-index --find-links .\%REPO_DIR%\dist %PKG_NAME%
   # Change into an innocuous directory and find tests from installation
   - mkdir for_testing

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 
 environment:
   global:
-    BUILD_COMMIT: master
+    BUILD_COMMIT: v0.10.0rc2
     REPO_DIR: statsmodels
     PKG_NAME: statsmodels
     NP_BUILD_DEP: "numpy==1.11.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,7 +88,7 @@ test_script:
   - 'echo backend : agg > matplotlibrc'
   - python --version
   - python -c "import statsmodels.api as sm; sm.show_versions();"
-  - python -c "import statsmodels; statsmodels.test(extra_args=['--skip-slow', '--skip-examples', '--tb=short'], exit=True)"
+  - python -c "import statsmodels; statsmodels.test(extra_args=['--skip-slow', '--skip-examples', '--tb=short', '-n 2'], exit=True)"
   - cd ..
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,13 +3,14 @@
 
 environment:
   global:
-    BUILD_COMMIT: v0.9.0
+    BUILD_COMMIT: master
     REPO_DIR: statsmodels
     PKG_NAME: statsmodels
     NP_BUILD_DEP: "numpy==1.11.0"
     NP_TEST_DEP: "numpy==1.11.0"
     SP_BUILD_DEP: "scipy"
     SP_TEST_DEP: "scipy"
+    PANDAS_DEP: "pandas==0.20"
     EXTRA_FLAGS: ""
     CYTHON_DEP: "Cython==0.27.3"
     WHEELHOUSE_UPLOADER_USERNAME: travis-worker
@@ -26,15 +27,19 @@ environment:
       # Need 1.13 for h5py (h5py linked against 1.13)
       NP_BUILD_DEP: "numpy==1.13"
       NP_TEST_DEP: "numpy==1.13"
+      PANDAS_DEP: "pandas"
     - PYTHON: C:\Python36-x64
       NP_BUILD_DEP: "numpy==1.13"
       NP_TEST_DEP: "numpy==1.13"
+      PANDAS_DEP: "pandas"
     - PYTHON: C:\Python37
       NP_BUILD_DEP: "numpy==1.14.5"
       NP_TEST_DEP: "numpy==1.14.5"
+      PANDAS_DEP: "pandas"
     - PYTHON: C:\Python37-x64
       NP_BUILD_DEP: "numpy==1.14.5"
       NP_TEST_DEP: "numpy==1.14.5"
+      PANDAS_DEP: "pandas"
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
@@ -66,8 +71,6 @@ install:
   - git submodule update --init
   # Build wheel
   - cd %REPO_DIR%
-  # Add my repository, for fixes
-  - git remote add mb https://github.com/matthew-brett/statsmodels.git --fetch
   - git checkout %BUILD_COMMIT%
   - python setup.py bdist_wheel
   - cd ..
@@ -76,7 +79,7 @@ build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
   # Install the test dependencies
-  - pip install %NP_TEST_DEP% %SP_TEST_DEP% patsy pandas nose "pytest<4" pytest-xdist
+  - pip install %NP_TEST_DEP% %SP_TEST_DEP% patsy %PANDAS_DEP% nose pytest pytest-xdist
   - pip install --pre --no-index --find-links .\%REPO_DIR%\dist %PKG_NAME%
   # Change into an innocuous directory and find tests from installation
   - mkdir for_testing
@@ -85,7 +88,7 @@ test_script:
   - 'echo backend : agg > matplotlibrc'
   - python --version
   - python -c "import statsmodels.api as sm; sm.show_versions();"
-  - python -c "import statsmodels; statsmodels.test(exit=True)"
+  - python -c "import statsmodels; statsmodels.test(extra_args=['--skip-slow', '--skip-examples', '--tb=short'], exit=True)"
   - cd ..
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 
 environment:
   global:
-    BUILD_COMMIT: master
+    BUILD_COMMIT: 797c613
     REPO_DIR: statsmodels
     PKG_NAME: statsmodels
     NP_BUILD_DEP: "numpy==1.11.0"
@@ -72,6 +72,8 @@ install:
   - git submodule update --init
   # Build wheel
   - cd %REPO_DIR%
+  - git remote add https://github.com/thequackdaddy/statsmodels
+  - git fetch --all
   - git checkout %BUILD_COMMIT%
   - python setup.py bdist_wheel
   - cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,8 +72,6 @@ install:
   - git submodule update --init
   # Build wheel
   - cd %REPO_DIR%
-  - git remote add https://github.com/thequackdaddy/statsmodels
-  - git fetch --all
   - git checkout %BUILD_COMMIT%
   - python setup.py bdist_wheel
   - cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,8 @@ environment:
     PKG_NAME: statsmodels
     NP_BUILD_DEP: "numpy==1.11.0"
     NP_TEST_DEP: "numpy==1.11.0"
-    SP_BUILD_DEP: "scipy"
-    SP_TEST_DEP: "scipy"
+    SP_BUILD_DEP: "scipy==1.2"
+    SP_TEST_DEP: "scipy==1.2"
     PANDAS_DEP: "pandas==0.20"
     EXTRA_FLAGS: ""
     CYTHON_DEP: "Cython==0.27.3"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ environment:
     WHEELHOUSE_UPLOADER_SECRET:
       secure: 9s0gdDGnNnTt7hvyNpn0/ZzOMGPdwPp2SewFTfGzYk7uI+rdAN9rFq2D1gAP4NQh
     DAILY_COMMIT: master
+    PYTHONHASHSEED: 0  # For xdist
 
   matrix:
     - PYTHON: C:\Python27

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 
 environment:
   global:
-    BUILD_COMMIT: 797c613
+    BUILD_COMMIT: master
     REPO_DIR: statsmodels
     PKG_NAME: statsmodels
     NP_BUILD_DEP: "numpy==1.11.0"

--- a/config.sh
+++ b/config.sh
@@ -18,5 +18,5 @@ function run_tests {
     # Check OpenBLAS core
     export OPENBLAS_VERBOSE=2
     python -c 'import statsmodels.api as sm; sm.show_versions();'
-    python -c 'import statsmodels; statsmodels.test(exit=True)'
+    python -c 'import statsmodels; statsmodels.test(extra_args=["--skip-slow", "--skip-examples", "--tb=short"], exit=True)'
 }

--- a/config.sh
+++ b/config.sh
@@ -18,5 +18,5 @@ function run_tests {
     # Check OpenBLAS core
     export OPENBLAS_VERBOSE=2
     python -c 'import statsmodels.api as sm; sm.show_versions();'
-    python -c 'import statsmodels; statsmodels.test(extra_args=["--skip-slow", "--skip-examples", "--tb=short"], exit=True)'
+    python -c 'import statsmodels; statsmodels.test(extra_args=["--skip-slow", "--skip-examples", "--tb=short", "-n 2"], exit=True)'
 }

--- a/config.sh
+++ b/config.sh
@@ -18,5 +18,6 @@ function run_tests {
     # Check OpenBLAS core
     export OPENBLAS_VERBOSE=2
     python -c 'import statsmodels.api as sm; sm.show_versions();'
-    python -c 'import statsmodels; statsmodels.test(extra_args=["--skip-slow", "--skip-examples", "--tb=short", "-n 2"], exit=True)'
+    [ -n "$IS_OSX" ] && python -c 'import statsmodels; statsmodels.test(extra_args=["--skip-slow", "--skip-examples", "--tb=short", "-n 2"], exit=True)' && exit
+    python -c 'import statsmodels; statsmodels.test(extra_args=["--skip-slow", "--skip-examples", "--tb=short"], exit=True)'
 }

--- a/config.sh
+++ b/config.sh
@@ -18,6 +18,9 @@ function run_tests {
     # Check OpenBLAS core
     export OPENBLAS_VERBOSE=2
     python -c 'import statsmodels.api as sm; sm.show_versions();'
-    [ -n "$IS_OSX" ] && python -c 'import statsmodels; statsmodels.test(extra_args=["--skip-slow", "--skip-examples", "--tb=short", "-n 2"], exit=True)' && exit
-    python -c 'import statsmodels; statsmodels.test(extra_args=["--skip-slow", "--skip-examples", "--tb=short"], exit=True)'
+    if [ -n "$IS_OSX" ]; then
+        python -c 'import statsmodels; statsmodels.test(extra_args=["--skip-slow", "--skip-examples", "--tb=short", "-n 2"], exit=True)'
+    else
+        python -c 'import statsmodels; statsmodels.test(extra_args=["--skip-slow", "--skip-examples", "--tb=short"], exit=True)'
+    fi
 }


### PR DESCRIPTION
Pandas appears to be entering version hell. That's breaking your build. 

Also, I removed the Linux python 3.7 i686 build as there's no pandas support for that, it seems. 

Lastly, I changed the tests to skip the slower tests. 

There still seems to be a failure on the Mac builds. I'll try to look into that. Its a little hard to replicate, however. The mac builds on the statsmodels repo work. Statsmodels Mac support is known to be temperamental, granted.