### PR TITLE
MAINT: Fix NumPy versions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,14 +43,14 @@ environment:
       PANDAS_DEP: "pandas"
     - PYTHON: C:\Python38
       NP_BUILD_DEP: "numpy==1.17.4"
-      NP_TEST_DEP: "numpy==1.14.5"
+      NP_TEST_DEP: "numpy==1.17.4"
       SP_BUILD_DEP: "scipy==1.3.2"
       SP_TEST_DEP: "scipy==1.3.2"
       PANDAS_DEP: "pandas"
       CYTHON_DEP: "Cython==0.29.14"
     - PYTHON: C:\Python38-x64
       NP_BUILD_DEP: "numpy==1.17.4"
-      NP_TEST_DEP: "numpy==1.14.5"
+      NP_TEST_DEP: "numpy==1.17.4"
       SP_BUILD_DEP: "scipy==1.3.2"
       SP_TEST_DEP: "scipy==1.3.2"
       PANDAS_DEP: "pandas"


### PR DESCRIPTION
Ensure 1.17 is used for 3.8