### PR TITLE
Enable arch arm64 for macOS

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -5,8 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  schedule:
-    - cron: '0 0 * * 0,3' # 2/weekly
+  # schedule:
+  #   - cron: '0 0 * * 0,3' # 2/weekly
 
 jobs:
   build_wheels:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -5,8 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  # schedule:
-  #   - cron: '0 0 * * 0,3' # 2/weekly
+  schedule:
+    - cron: '0 0 * * 0,3' # 2/weekly
 
 jobs:
   build_wheels:
@@ -14,10 +14,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # python: ["cp37", "cp38", "cp39", "cp310"]
-        python: ["cp39"]
-        # os: [ubuntu-20.04, windows-2019, macOS-10.15]
-        os: [macOS-10.15]
+        python: ["cp37", "cp38", "cp39", "cp310"]
+        os: [ubuntu-20.04, windows-2019, macOS-10.15]
     env:
       CIBW_BUILD: ${{ matrix.python }}-*
       CIBW_ARCHS_LINUX: "x86_64"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -14,10 +14,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python: ["cp37", "cp38", "cp39", "cp310"]
-        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+        # python: ["cp37", "cp38", "cp39", "cp310"]
+        python: ["cp39"]
+        # os: [ubuntu-20.04, windows-2019, macOS-10.15]
+        os: [macOS-10.15]
     env:
       CIBW_BUILD: ${{ matrix.python }}-*
+      CIBW_ARCHS_LINUX: "x86_64"
+      CIBW_ARCHS_MACOS: "x86_64 arm64"
+      CIBW_ARCHS_WINDOWS: "AMD64"
       CIBW_SKIP: "pp* *-win32 *-manylinux_i686 *-musllinux_i686 *-musllinux_x86_64"
       CIBW_TEST_REQUIRES: pytest pytest-xdist
       CIBW_TEST_COMMAND: python -c "import statsmodels; statsmodels.test(['--skip-examples','--skip-slow','-n','2'])"


### PR DESCRIPTION
This seems to have worked: https://github.com/mbarkhau/statsmodels-wheels/runs/4717035861?check_suite_focus=true

```
Created wheel for statsmodels: filename=statsmodels-0.14.0.dev0+168.g590384e8b-cp39-cp39-macosx_10_9_x86_64.whl size=9679850 sha256=1407c4e2aac3f6c7b3a1b39d4dcb0b915d4e76385fbe367e2f35b8a85bfe56b0

Created wheel for statsmodels: filename=statsmodels-0.14.0.dev0+168.g590384e8b-cp39-cp39-macosx_11_0_arm64.whl size=9161792 sha256=b64e56d63096796ee1cf2e9f05af53b3ad6b1ae6ba18e93c6aaee99c23287700

Warning: While arm64 wheels can be built on x86_64, they cannot be tested. The ability to test the arm64 wheels will be added in a future release of cibuildwheel, once Apple Silicon CI runners are widely available. To silence this warning, set `CIBW_TEST_SKIP: *-macosx_arm64`.
```

The output indicates that the wheel was built for both architectures, but could only be tested on x86_64.
I'm not sure why I can't download the wheel files to test locally.
