### PR TITLE
MAINT: Stop 3.8 from building

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [cp38, cp39, cp310, cp311, cp312]
+        python: [cp39, cp310, cp311, cp312]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     env:
       BUILD_COMMIT: "main"  # or a specific version, e.g., v0.13.1
@@ -46,18 +46,18 @@ jobs:
           fetch-depth: 0
 
       # Used to host cibuildwheel
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.0
+        run: python -m pip install cibuildwheel==2.16.2
 
       - name: Build wheels
         run: |


### PR DESCRIPTION
Minimum Python is now 3.9