### PR TITLE
Build and publish Pyodide wheels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -122,7 +122,7 @@ jobs:
       BUILD_COMMIT: "main"  # or a specific version, e.g., v0.13.1
       CIBW_PLATFORM: pyodide
       CIBW_TEST_REQUIRES: pytest
-      CIBW_TEST_COMMAND: python -c "import statsmodels; statsmodels.test(['--skip-examples','--skip-slow')"
+      CIBW_TEST_COMMAND: python -c "import statsmodels; statsmodels.test(['--skip-examples','--skip-slow'])"
       MULTIBUILD_WHEELS_STAGING_ACCESS: ${{ secrets.MULTIBUILD_WHEELS_STAGING_ACCESS }}
       SCIENTIFIC_PYTHON_NIGHTLY_WHEELS: ${{ secrets.SCIENTIFIC_PYTHON_NIGHTLY_WHEELS }}
       MKL_NUM_THREADS: 1

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build_wheels:
-    name: ${{ matrix.os }}, Python ${{ matrix.python }}
+    name: ${{ matrix.os }}, ${{matrix.python_impl }} ${{ matrix.python }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -20,6 +20,11 @@ jobs:
       matrix:
         python: [cp39, cp310, cp311, cp312]
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        python_impl: [Python]
+        include:
+          - python: cp312
+            os: ubuntu-latest
+            python_impl: Pyodide
     env:
       BUILD_COMMIT: "main"  # or a specific version, e.g., v0.13.1
       CIBW_BUILD: ${{ matrix.python }}-*
@@ -58,93 +63,24 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.20.0
+        if: matrix.python_impl != 'Pyodide'
         with:
           output-dir: wheelhouse
           package-dir: statsmodels
         env:
           CIBW_BEFORE_BUILD: 'git submodule foreach git checkout  ${{ env.BUILD_COMMIT }}'
 
-      - name: Setup Upload Variables
-        if: ${{ always() }}
-        shell: bash
-        run: |
-          if [ "schedule" == "${{ github.event_name }}" ] || [ "push" == "${{ github.event_name }}" ]; then
-            echo "ANACONDA_UPLOAD=true" >> $GITHUB_ENV
-          else
-            echo "ANACONDA_UPLOAD=false" >> $GITHUB_ENV
-          fi
-          if [ "schedule" == "${{ github.event_name }}" ] || [ "main" == "$BUILD_COMMIT" ]; then
-            echo "ANACONDA_ORG=scientific-python-nightly-wheels" >> $GITHUB_ENV
-            echo "TOKEN=$SCIENTIFIC_PYTHON_NIGHTLY_WHEELS" >> $GITHUB_ENV
-          else
-            echo "ANACONDA_ORG=multibuild-wheels-staging" >> $GITHUB_ENV
-            echo "TOKEN=$MULTIBUILD_WHEELS_STAGING_ACCESS" >> $GITHUB_ENV
-          fi
-      - name: Upload wheels
-        if: ${{ always() }}
-        shell: bash
-        run: |
-          # trigger an upload to the shared ecosystem
-          # infrastructure at: https://anaconda.org/scientific-python-nightly-wheels
-          # for cron jobs only (restricted to main branch once
-          # per week)
-          # SCIENTIFIC_PYTHON_NIGHTLY_WHEELS is a secret token
-          # used in Travis CI config, originally
-          #
-          # for merges (push events) we use the staging area instead;
-          # MULTIBUILD_WHEELS_STAGING_ACCESS is a secret token used in Travis
-          # CI config, originally generated at anaconda.org for
-          # multibuild-wheels-staging
-          # generated at anaconda.org for scientific-python-nightly-wheels
-          echo ${PWD}
-          if [ ${ANACONDA_UPLOAD} == true ]; then
-            # main branches of these two packages
-            python --version
-            python -m pip install "cython<3"
-            python -m pip list
-            python -m pip install git+https://github.com/bashtage/clyent.git
-            python -m pip install git+https://github.com/Anaconda-Server/anaconda-client.git
-            python -m pip install "urllib3>=1.21.1,<2"
-            ls ./wheelhouse/*.whl
-            anaconda -t ${TOKEN} upload --force -u ${ANACONDA_ORG} ./wheelhouse/*.whl
-            echo "PyPI-style index: https://pypi.anaconda.org/$ANACONDA_ORG/simple"
-          fi
-
-
-  # Same as the above job, but configurations swapped for Pyodide
-  build_pyodide_wheel:
-    name: ubuntu-latest, Pyodide cp312
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    env:
-      BUILD_COMMIT: "main"  # or a specific version, e.g., v0.13.1
-      CIBW_PLATFORM: pyodide
-      CIBW_TEST_REQUIRES: pytest
-      CIBW_TEST_COMMAND: python -c "import statsmodels; statsmodels.test(['--skip-examples','--skip-slow'])"
-      MULTIBUILD_WHEELS_STAGING_ACCESS: ${{ secrets.MULTIBUILD_WHEELS_STAGING_ACCESS }}
-      SCIENTIFIC_PYTHON_NIGHTLY_WHEELS: ${{ secrets.SCIENTIFIC_PYTHON_NIGHTLY_WHEELS }}
-      MKL_NUM_THREADS: 1
-      OMP_NUM_THREADS: 1
-      OPENLAS_NUM_THREADS: 1
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
-      # Used to host cibuildwheel runner
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
       - name: Build Pyodide wheel
+        if: matrix.python_impl == 'Pyodide'
         uses: pypa/cibuildwheel@v2.20.0
         with:
           output-dir: wheelhouse
           package-dir: statsmodels
+        env:
+          CIBW_BEFORE_BUILD: 'git submodule foreach git checkout  ${{ env.BUILD_COMMIT }}'
+          CIBW_PLATFORM: pyodide
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: python -c "import statsmodels; statsmodels.test(['--skip-examples','--skip-slow'])"
 
       - name: Setup Upload Variables
         if: ${{ always() }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -109,3 +109,91 @@ jobs:
             anaconda -t ${TOKEN} upload --force -u ${ANACONDA_ORG} ./wheelhouse/*.whl
             echo "PyPI-style index: https://pypi.anaconda.org/$ANACONDA_ORG/simple"
           fi
+
+
+  # Same as the above job, but configurations swapped for Pyodide
+  build_pyodide_wheel:
+    name: ubuntu-latest, Pyodide cp312
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      BUILD_COMMIT: "main"  # or a specific version, e.g., v0.13.1
+      CIBW_PLATFORM: pyodide
+      CIBW_TEST_REQUIRES: pytest
+      CIBW_TEST_COMMAND: python -c "import statsmodels; statsmodels.test(['--skip-examples','--skip-slow')"
+      MULTIBUILD_WHEELS_STAGING_ACCESS: ${{ secrets.MULTIBUILD_WHEELS_STAGING_ACCESS }}
+      SCIENTIFIC_PYTHON_NIGHTLY_WHEELS: ${{ secrets.SCIENTIFIC_PYTHON_NIGHTLY_WHEELS }}
+      MKL_NUM_THREADS: 1
+      OMP_NUM_THREADS: 1
+      OPENLAS_NUM_THREADS: 1
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      # Used to host cibuildwheel runner
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build Pyodide wheel
+        uses: pypa/cibuildwheel@v2.20.0
+        with:
+          output-dir: wheelhouse
+          package-dir: statsmodels
+
+        env:
+          CIBW_BEFORE_BUILD: 'git submodule foreach git checkout  ${{ env.BUILD_COMMIT }}'
+          CIBW_PLATFORM: pyodide
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: python -c "import statsmodels; statsmodels.test(['--skip-examples','--skip-slow'])
+
+      - name: Setup Upload Variables
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          if [ "schedule" == "${{ github.event_name }}" ] || [ "push" == "${{ github.event_name }}" ]; then
+            echo "ANACONDA_UPLOAD=true" >> $GITHUB_ENV
+          else
+            echo "ANACONDA_UPLOAD=false" >> $GITHUB_ENV
+          fi
+          if [ "schedule" == "${{ github.event_name }}" ] || [ "main" == "$BUILD_COMMIT" ]; then
+            echo "ANACONDA_ORG=scientific-python-nightly-wheels" >> $GITHUB_ENV
+            echo "TOKEN=$SCIENTIFIC_PYTHON_NIGHTLY_WHEELS" >> $GITHUB_ENV
+          else
+            echo "ANACONDA_ORG=multibuild-wheels-staging" >> $GITHUB_ENV
+            echo "TOKEN=$MULTIBUILD_WHEELS_STAGING_ACCESS" >> $GITHUB_ENV
+          fi
+      - name: Upload wheels
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          # trigger an upload to the shared ecosystem
+          # infrastructure at: https://anaconda.org/scientific-python-nightly-wheels
+          # for cron jobs only (restricted to main branch once
+          # per week)
+          # SCIENTIFIC_PYTHON_NIGHTLY_WHEELS is a secret token
+          # used in Travis CI config, originally
+          #
+          # for merges (push events) we use the staging area instead;
+          # MULTIBUILD_WHEELS_STAGING_ACCESS is a secret token used in Travis
+          # CI config, originally generated at anaconda.org for
+          # multibuild-wheels-staging
+          # generated at anaconda.org for scientific-python-nightly-wheels
+          echo ${PWD}
+          if [ ${ANACONDA_UPLOAD} == true ]; then
+            # main branches of these two packages
+            python --version
+            python -m pip install "cython<3"
+            python -m pip list
+            python -m pip install git+https://github.com/bashtage/clyent.git
+            python -m pip install git+https://github.com/Anaconda-Server/anaconda-client.git
+            python -m pip install "urllib3>=1.21.1,<2"
+            ls ./wheelhouse/*.whl
+            anaconda -t ${TOKEN} upload --force -u ${ANACONDA_ORG} ./wheelhouse/*.whl
+            echo "PyPI-style index: https://pypi.anaconda.org/$ANACONDA_ORG/simple"
+          fi

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -146,12 +146,6 @@ jobs:
           output-dir: wheelhouse
           package-dir: statsmodels
 
-        env:
-          CIBW_BEFORE_BUILD: 'git submodule foreach git checkout  ${{ env.BUILD_COMMIT }}'
-          CIBW_PLATFORM: pyodide
-          CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: python -c "import statsmodels; statsmodels.test(['--skip-examples','--skip-slow'])
-
       - name: Setup Upload Variables
         if: ${{ always() }}
         shell: bash

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -56,12 +56,11 @@ jobs:
         with:
           platforms: all
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.2
-
       - name: Build wheels
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse statsmodels
+        uses: pypa/cibuildwheel@v2.20.0
+        with:
+          output-dir: wheelhouse
+          package-dir: statsmodels
         env:
           CIBW_BEFORE_BUILD: 'git submodule foreach git checkout  ${{ env.BUILD_COMMIT }}'
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -50,11 +50,6 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      # Used to host cibuildwheel runner
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
       - name: Set up QEMU
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -35,8 +35,8 @@ jobs:
       CIBW_SKIP: "pp* *-win32 cp38-musllinux* cp39-musllinux* *musllinux_aarch64*"
       CIBW_TEST_REQUIRES: pytest pytest-xdist
       CIBW_TEST_COMMAND: python -c "import statsmodels; statsmodels.test(['--skip-examples','--skip-slow','-n','2'])"
-      # Avoid testing on emulated architectures
-      CIBW_TEST_SKIP: "*-*linux_{aarch64,ppc64le,s390x}"
+      # Avoid testing on emulated architectures and Pyodide
+      CIBW_TEST_SKIP: "*-*linux_{aarch64,ppc64le,s390x} *pyodide*"
       CIBW_REPAIR_WHEEL_COMMAND_LINUX: 'auditwheel repair --strip -w {dest_dir} {wheel}'
       MULTIBUILD_WHEELS_STAGING_ACCESS: ${{ secrets.MULTIBUILD_WHEELS_STAGING_ACCESS }}
       SCIENTIFIC_PYTHON_NIGHTLY_WHEELS: ${{ secrets.SCIENTIFIC_PYTHON_NIGHTLY_WHEELS }}
@@ -79,8 +79,9 @@ jobs:
         env:
           CIBW_BEFORE_BUILD: 'git submodule foreach git checkout  ${{ env.BUILD_COMMIT }}'
           CIBW_PLATFORM: pyodide
-          CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: python -c "import statsmodels; statsmodels.test(['--skip-examples','--skip-slow'])"
+          # Tests are slow, and statsmodels is tested out-of-tree on PRs in the main repository
+          # CIBW_TEST_REQUIRES: pytest
+          # CIBW_TEST_COMMAND: python -c "import statsmodels; statsmodels.test(['--skip-examples','--skip-slow'])"
 
       - name: Setup Upload Variables
         if: ${{ always() }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -62,7 +62,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.20.0
+        uses: pypa/cibuildwheel@v2.20
         if: matrix.python_impl != 'Pyodide'
         with:
           output-dir: wheelhouse
@@ -72,7 +72,7 @@ jobs:
 
       - name: Build Pyodide wheel
         if: matrix.python_impl == 'Pyodide'
-        uses: pypa/cibuildwheel@v2.20.0
+        uses: pypa/cibuildwheel@v2.20
         with:
           output-dir: wheelhouse
           package-dir: statsmodels


### PR DESCRIPTION
## Description

This PR implements a few things across the workflow(s):

1. Adds configuration via standard `CIBW_`-prefixed environment variables for building Pyodide wheels. This requires a bump to the `cibuildwheel` version, which has been updated to version 2.20.0, the latest available stable version. Support for building and publishing Pyodide wheels was introduced in [version `2.19.0`](https://github.com/pypa/cibuildwheel/releases/tag/v2.19.0).
2. Switches `cibuildwheel` from being pip-installed to its action as provided in the GitHub Actions marketplace
3. Adds a minimal Dependabot configuration file with weekly updates to bump the version for said action (and others). It can be triggered monthly, if needed.

> [!NOTE]
> I didn't run the test command for the Pyodide wheel step as of now, because of two reasons:
>
> 1. Pyodide support is now tested in out-of-tree PR builds in the main repository, as linked in the PR below. Of course, this is not a valid enough reason because this is a separate environment altogether. However, there's still the problem of a Pyodide fatal error coming from a missing `pow_dd` symbol when running the test suite (which I'll return in a while to investigate). If I am requested to enable the testing by the maintainers here, I can bring the alternative Node.js-based test runner file where the symbol visibility bug doesn't post a problem and use it to test the wheel here. Alternatively, the statsmodels submodule in this repository can be updated, and the file will appear. Please let me know if you would like me to do that.
> 2. The Pyodide test suite is slower than other jobs because threading/multiprocessing is disabled in a WebAssembly-based environment, and `pytest-xdist` is not usable. Hence, testing the wheels takes much longer (~30 minutes). It will still be faster than the ["ubuntu-latest, Python cp3X"](https://github.com/agriyakhetarpal/statsmodels-wheels/actions/runs/10620634937/job/29440825084?pr=1) jobs, however[^1].

This is a follow-up PR after statsmodels/statsmodels#9270, which describes the rationale for this change. Please let me know if points two and three are better placed in a separate PR. Thank you!

[^1]: Those jobs run for more than an hour, would it be alright if I parallelise them across the trio of manylinux-x86_64, musllinux-x86_64, and manylinux-aarch64? Doing this will lead to a 43% speedup – if yes, I could do so in a separate PR to keep the diff cleaner.