### PR TITLE
ENH: Add Python 313

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [cp39, cp310, cp311, cp312, cp313]
+        python: [cp310, cp311, cp312, cp313]
         os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
         python_impl: [Python]
         include:


### PR DESCRIPTION
I noticed there are no 3.13 wheels here

https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/statsmodels/

This attempts to add them!